### PR TITLE
Upgrade to latest schema validator + add support for resultion scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,17 @@ Example implementation and usage in ColdFusion cfscript:
 ```cfml
 // CFC wrapper
 component displayName="JSONSchemaValidator"{
-  public component function isValid(required string schema){
-    return createObject("java", "ca.vanmulligen.json.schema.Validator").init(arguments.schema);
+  
+  function init(required string schema, string resolutionScope="") {
+    if ( Len( Trim( arguments.resolutionScope ) ) ) {
+      variables.validator = createObject("java", "ca.vanmulligen.json.schema.Validator").init(arguments.schema, arguments.resolutionScope);
+    } else {
+      variables.validator = createObject("java", "ca.vanmulligen.json.schema.Validator").init(arguments.schema);
+    }
+  }
+
+  public struct function isValid(required string schema){
+    return DeserializeJson( validator.isValid( arguments.schema ) );
   }
 }
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -6,24 +6,47 @@
   <name>JSONSchemaValidator</name>
   <description>JSONSchemaValidator</description>
   <dependencies>
-	<dependency>
-	    <groupId>org.everit.json</groupId>
-	    <artifactId>org.everit.json.schema</artifactId>
-	    <version>1.5.1</version>
-	</dependency>
-	<dependency>
-	    <groupId>org.json</groupId>
-	    <artifactId>json</artifactId>
-	    <version>20180813</version>
-	</dependency>
+    <dependency>
+        <groupId>com.github.everit-org.json-schema</groupId>
+        <artifactId>org.everit.json.schema</artifactId>
+        <version>1.12.1</version>
+    </dependency>
+  	<dependency>
+  	    <groupId>org.json</groupId>
+  	    <artifactId>json</artifactId>
+  	    <version>20180813</version>
+  	</dependency>
   </dependencies>
-  <build>
+  <repositories>
+    <repository>
+        <id>jitpack.io</id>
+        <url>https://jitpack.io</url>
+    </repository>
+  </repositories>
+ <build>
   	<plugins>
   		<plugin>
   			<groupId>org.apache.maven.plugins</groupId>
   			<artifactId>maven-shade-plugin</artifactId>
   			<version>2.3</version>
   		</plugin>
+      <plugin>
+        <artifactId>maven-assembly-plugin</artifactId>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>single</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <descriptorRefs>
+            <descriptorRef>jar-with-dependencies</descriptorRef>
+          </descriptorRefs>
+        </configuration>
+      </plugin>
   	</plugins>
   </build>
 </project>
+

--- a/src/main/java/ca/vanmulligen/json/schema/Validator.java
+++ b/src/main/java/ca/vanmulligen/json/schema/Validator.java
@@ -8,26 +8,46 @@ import org.json.JSONTokener;
 
 public class Validator
 {
-	private String rawJSONSchema;
-	
+	private Schema schema;
+
 	public Validator(String rawJSONSchema){
-		this.rawJSONSchema = rawJSONSchema;
+		_setupSchema(rawJSONSchema, null);
 	}
-	
-	public String isValid(String testableJSON) throws Exception { 
+
+	public Validator(String rawJSONSchema, String resolutionScope){
+		_setupSchema(rawJSONSchema, resolutionScope);
+	}
+
+	public String isValid(String testableJSON) throws Exception {
 		JSONObject results = new JSONObject();
 		results.put("error", "");
-		
+
 		try {
-			JSONObject schemaJSONObect = new JSONObject(new JSONTokener(rawJSONSchema));
-			Schema schema = SchemaLoader.load(schemaJSONObect);
-			schema.validate(new JSONObject(testableJSON));
+			this.schema.validate(new JSONObject(testableJSON));
 		} catch (ValidationException e) {
 			results.put("valid", false);
 			results.put("error", e.toJSON());
 			return results.toString();
-		} 
+		}
 		results.put("valid", true);
 		return results.toString();
+	}
+
+	private void _setupSchema(String rawJSONSchema, String resolutionScope) {
+		JSONObject schemaJson = new JSONObject(new JSONTokener(rawJSONSchema));
+		SchemaLoader loader;
+
+		if(resolutionScope != null) {
+			loader = SchemaLoader.builder()
+			    .schemaJson(schemaJson)
+			    .resolutionScope(resolutionScope)
+			    .build();
+		} else {
+			loader = SchemaLoader.builder()
+			    .schemaJson(schemaJson)
+			    .build();
+		}
+
+		this.schema = loader.load().build();
 	}
 }


### PR DESCRIPTION
This PR updates the underlying schema library to the latest release and adds support for resolution scopes. Resolution scopes allow the including of sub-schemas using the `$ref` property. See https://github.com/everit-org/json-schema#ref-resolution